### PR TITLE
Improve description of the tool output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,6 @@ Apparently, this application is running on Mac OS X with JDK 19.
 [success] Total time: 2 s, completed 12 Oct 2022, 17:59:26
 sbt:helloworld>
 ```
-The application will ask you for your name and then print back a simple greeting.
+The application will ask you for your name and then print back a simple greeting,
+and your OS and JDK versions.
 After exiting, sbt is now ready to take the next command.

--- a/README.md
+++ b/README.md
@@ -60,5 +60,5 @@ Apparently, this application is running on Mac OS X with JDK 19.
 sbt:helloworld>
 ```
 The application will ask you for your name and then print back a simple greeting,
-and your OS and JDK versions.
+and your operating system and JDK versions.
 After exiting, sbt is now ready to take the next command.


### PR DESCRIPTION
The description of the tool output just says that a greeting will be displayed. But we shouldn't sell our software short: We also detect the OS and the JDK version and output them to the user, which can be really helpful to potential users.

This PR adds a half-sentence to the description to highlight this fact.